### PR TITLE
Fix highlight on click for access control

### DIFF
--- a/libs/builder/builder.js
+++ b/libs/builder/builder.js
@@ -1639,15 +1639,19 @@ Vvveb.Builder = {
 
 		self.frameBody.addEventListener("dblclick", highlightDbClick);
 
-		let highlightClick = function (event) {
+               let highlightClick = function (event) {
 
-			if (Vvveb.Builder.isPreview == false) {
-				if (event.target) {
-					let canEdit = Vvveb.Access.canEditNode(event.target);
-					if (Vvveb.WysiwygEditor.isActive) {
-						if (self.texteditEl.contains(event.target)) {
-							return true;
-						}
+                       if (Vvveb.Builder.isPreview == false) {
+                               if (event.target) {
+                                       let canEdit = Vvveb.Access.canEditNode(event.target);
+                                       if (!canEdit) {
+                                               document.getElementById("highlight-box").style.display = "none";
+                                               return;
+                                       }
+                                       if (Vvveb.WysiwygEditor.isActive) {
+                                               if (self.texteditEl.contains(event.target)) {
+                                                       return true;
+                                               }
 					}
 					//if component properties is loaded in left panel tab instead of right panel show tab
 					let componentTab = document.querySelector(".component-properties-tab a");


### PR DESCRIPTION
## Summary
- restrict click highlighting to editable elements

## Testing
- `npm test` *(fails: Error: no test specified)*